### PR TITLE
Correct typo in FFPROBE env var

### DIFF
--- a/setup/nobody/start.sh
+++ b/setup/nobody/start.sh
@@ -6,7 +6,7 @@
 export MONO='/usr/bin/mono'
 export PROGRAM_DATA='/config'
 export FFMPEG='/usr/bin/ffmpeg'
-export FFPROBE='/uar/bin/ffprobe'
+export FFPROBE='/usr/bin/ffprobe'
 
 # kick off main process
 exec '/usr/bin/emby-server'


### PR DESCRIPTION
This prevented Emby from probing for mediainfo, and caused problems with transcoding as well.

BTW, would you consider exposing FFMPEG and FFPROBE in the Dockerfile? Arch's old version is really slow on my my hardware so I'd like to use something more recent while waiting for them to update.
